### PR TITLE
fix: Do not apply retry when status code is 429

### DIFF
--- a/src/Routes/BaseRouter.php
+++ b/src/Routes/BaseRouter.php
@@ -190,7 +190,7 @@ abstract class BaseRouter
       $status = $response['statusCode'];
       $data = $response['data'];
 
-      if (!is_null($status) && $status < 500 && $status != 429) {
+      if (!is_null($status) && $status < 500) {
         return new AdvisorResponse($data);
       }
 


### PR DESCRIPTION
### Motivation

Make the error response come without retrying the request

### Solution

Remove the statusCode = 429 condition from codes

## ✅ Checklist

- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) as default commits;
- [x] My change respects or improves the architecture defined for the project;
- [ ] I wrote or changed tests associated with my move;
- [ ] I ran the tests linked to my change locally and they passed;
- [x] I've tagged everyone who needs to review/get context on the change.
- [x] I have updated the application version following the [semantic versioning](https://docs.npmjs.com/about-semantic-versioning);
